### PR TITLE
Configurable sorting priority throught setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,14 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Format uses section automatically after first activation"
+                },
+                "pascal-uses-formatter.overrideSortingOrder": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "description": "Override default namespace sorting logic with custom namespace sorting logic. Inputted namespaces will be preferred by sorting logic"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
                         "type": "string"
                     },
                     "default": [],
-                    "description": "Override default namespace sorting. Configure sorting priority by adding namespace to array"
+                    "description": "Override default namespace sorting order. Configure sorting priority by adding namespace to array"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
                         "type": "string"
                     },
                     "default": [],
-                    "description": "Override default namespace sorting logic with custom namespace sorting logic. Inputted namespaces will be preferred by sorting logic"
+                    "description": "Override default namespace sorting. Configure sorting priority by adding namespace to array"
                 }
             }
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -40,9 +40,9 @@ function formatDocument(editor: TextEditor, edit: TextEditorEdit)
   const separator = getSeparator(editor.options);
   const lineEnd = getLineEnd(doc.eol);
   const text = doc.getText();
-  const overriddenNamespaceSortingArray = getOverriddenNamespacesArray();
+  const configuratbleSortingArray = getOverriddenNamespacesArray();
 
-  const newSections = formatText(text, separator, lineEnd, overriddenNamespaceSortingArray);
+  const newSections = formatText(text, separator, lineEnd, configuratbleSortingArray);
   if(newSections.length === 0)
   {
     vscode.window.showInformationMessage('pascal-uses-formatter: could not find any uses section.');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,11 @@ interface IUsesFormatterState {
   context: vscode.ExtensionContext;
 }
 
+function getOverriddenNamespacesArray() : string[]
+{
+    return (vscode.workspace.getConfiguration('pascal-uses-formatter').get('overrideSortingOrder')) as Array<string>;
+}
+
 function getLineEnd(eol: EndOfLine): string
 {
   switch(eol) {
@@ -35,8 +40,9 @@ function formatDocument(editor: TextEditor, edit: TextEditorEdit)
   const separator = getSeparator(editor.options);
   const lineEnd = getLineEnd(doc.eol);
   const text = doc.getText();
+  const overriddenNamespaceSortingArray = getOverriddenNamespacesArray();
 
-  const newSections = formatText(text, separator, lineEnd);
+  const newSections = formatText(text, separator, lineEnd, overriddenNamespaceSortingArray);
   if(newSections.length === 0)
   {
     vscode.window.showInformationMessage('pascal-uses-formatter: could not find any uses section.');

--- a/src/test/suite/usesFormatter.test.ts
+++ b/src/test/suite/usesFormatter.test.ts
@@ -26,7 +26,7 @@ const test = (sample: TestSample): void =>
   const separator = "  ";
   const lineEnd = "\n";
 
-  const replaces = formatText(sample.input, separator, lineEnd);
+  const replaces = formatText(sample.input, separator, lineEnd, []);
   expect(replaces).to.eql(sample.output);
 };
 

--- a/src/usesFormatter.ts
+++ b/src/usesFormatter.ts
@@ -25,15 +25,17 @@ const parseUnits = (text:string): string[] => {
     .split(',');
 };
 
-function formatUsesSection(units: string[], separator: string, lineEnd: string, overriddenNamespaceSortingArray: string[]): string
+function formatUsesSection(units: string[], separator: string, lineEnd: string, configuratbleSortingArray: string[]): string
 {
   const sortFun = (a: string, b: string) => {
-    for(let namespace of overriddenNamespaceSortingArray){
+    for(let namespace of configuratbleSortingArray){
         let normalizedNamespace = namespace.toLowerCase();
-        if(a.trim().toLocaleLowerCase().startsWith(normalizedNamespace) && !b.trim().toLocaleLowerCase().startsWith(normalizedNamespace)){
+        let normalizedA = a.trim().toLocaleLowerCase();
+        let normalizedB = b.trim().toLocaleLowerCase();
+        if(normalizedA.startsWith(normalizedNamespace) && !normalizedB.startsWith(normalizedNamespace)){
             return -1;
         }
-        else if(!a.trim().toLocaleLowerCase().startsWith(normalizedNamespace) && b.trim().toLocaleLowerCase().startsWith(normalizedNamespace)){
+        else if(!normalizedA.startsWith(normalizedNamespace) && normalizedB.startsWith(normalizedNamespace)){
             return 1;
         }
     }
@@ -44,12 +46,12 @@ function formatUsesSection(units: string[], separator: string, lineEnd: string, 
   return `uses${lineEnd}${separator}${formattedUnits};`;
 }
 
-export function formatText(text: string, separator: string, lineEnd: string, overriddenNamespaceSortingArray: string[]): ITextSection[] {
+export function formatText(text: string, separator: string, lineEnd: string, configuratbleSortingArray: string[]): ITextSection[] {
   return findUsesSections(text).map((section: ITextSection): ITextSection => {
     return {
       startOffset: section.startOffset,
       endOffset: section.endOffset,
-      value: formatUsesSection(parseUnits(section.value),  separator, lineEnd, overriddenNamespaceSortingArray)
+      value: formatUsesSection(parseUnits(section.value),  separator, lineEnd, configuratbleSortingArray)
     };
   });
 }

--- a/src/usesFormatter.ts
+++ b/src/usesFormatter.ts
@@ -25,9 +25,18 @@ const parseUnits = (text:string): string[] => {
     .split(',');
 };
 
-function formatUsesSection(units: string[], separator: string, lineEnd: string): string
+function formatUsesSection(units: string[], separator: string, lineEnd: string, overriddenNamespaceSortingArray: string[]): string
 {
   const sortFun = (a: string, b: string) => {
+    for(let namespace of overriddenNamespaceSortingArray){
+        let normalizedNamespace = namespace.toLowerCase();
+        if(a.trim().toLocaleLowerCase().startsWith(normalizedNamespace) && !b.trim().toLocaleLowerCase().startsWith(normalizedNamespace)){
+            return -1;
+        }
+        else if(!a.trim().toLocaleLowerCase().startsWith(normalizedNamespace) && b.trim().toLocaleLowerCase().startsWith(normalizedNamespace)){
+            return 1;
+        }
+    }
     return a.localeCompare(b, undefined, {sensitivity: 'base'});
   };
 
@@ -35,12 +44,12 @@ function formatUsesSection(units: string[], separator: string, lineEnd: string):
   return `uses${lineEnd}${separator}${formattedUnits};`;
 }
 
-export function formatText(text: string, separator: string, lineEnd: string): ITextSection[] {
+export function formatText(text: string, separator: string, lineEnd: string, overriddenNamespaceSortingArray: string[]): ITextSection[] {
   return findUsesSections(text).map((section: ITextSection): ITextSection => {
     return {
       startOffset: section.startOffset,
       endOffset: section.endOffset,
-      value: formatUsesSection(parseUnits(section.value),  separator, lineEnd)
+      value: formatUsesSection(parseUnits(section.value),  separator, lineEnd, overriddenNamespaceSortingArray)
     };
   });
 }


### PR DESCRIPTION

You made a great extension which does the job really well
But in my company, we prefer custom sorting, to separate our units from system/3rd party units.
So we use sorting like this:

- System.*
- Winapi.*
- MyCopmany.System
- MyCompany.Common
- MyCompany.*
- ...

So, I implemented the feature and made it configurable through settings, where user can define custom namespace sorting priority. 

![Desktop-20200911-21283301](https://user-images.githubusercontent.com/22248235/92966085-2eb32780-f477-11ea-98a0-9ee789e7941c.gif)
