### PR TITLE
Issue #25: Do not sort intermediate uses sections

### DIFF
--- a/src/usesFormatter.ts
+++ b/src/usesFormatter.ts
@@ -5,14 +5,14 @@ export interface ITextSection {
 }
 
 const findUsesSections = (text: string): ITextSection[]  => {
-  const regex = /uses[\s\w.,]+;/g;
+  const regex = /(?:(?:interface|implementation|program\s+\S+;)\s+)(uses[\s\w.,]+;)/gid;
   const results: ITextSection[] = [];
   let match = null;
   while ((match = regex.exec(text)) !== null) {
     results.push({
-      startOffset: match.index,
-      endOffset: match.index + match[0].length,
-      value: match[0]
+        startOffset: match.index + match[0].length - match[1].length,
+        endOffset: match.index + match[0].length,
+        value: match[1]
     });
   }
   return results;

--- a/testExamples/ex2.correct.test.pas
+++ b/testExamples/ex2.correct.test.pas
@@ -15,8 +15,9 @@ uses
   u,
   y;
 
+// will not be sorted due to extra k in front of uses
 implementation
-uses
+kuses
   b,
   c,
   f,
@@ -29,7 +30,7 @@ uses
   u,
   y;
 
-implementation
+// Will not be sorted, because it does not follow a valid interface/implementation section definition
 uses
   Generics.Collections.patched,
   MemoryGuard,

--- a/testExamples/ex2.original.test.pas
+++ b/testExamples/ex2.original.test.pas
@@ -15,8 +15,9 @@ uses
   u,
   y;
 
+// will not be sorted due to extra k in front of uses
 implementation
-uses
+kuses
   b,
   c,
   f,
@@ -29,7 +30,7 @@ uses
   u,
   y;
 
-implementation
+// Will not be sorted, because it does not follow a valid interface/implementation section definition
 uses
   Generics.Collections.patched,
   MemoryGuard,


### PR DESCRIPTION
Only sort valid uses sections, so if they follow a interface, implementation, or program definition.